### PR TITLE
Fixes to Cloud9 pre-requisite scripts 

### DIFF
--- a/Cloud9Setup/increase-disk-size.sh
+++ b/Cloud9Setup/increase-disk-size.sh
@@ -1,32 +1,61 @@
-REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region)
-aws configure set profile.default.region $REGION
+#!/bin/bash
 
+# Specify the desired volume size in GiB as a command line argument. If not specified, default to 50 GiB.
 SIZE=50
 
 # Get the ID of the environment host Amazon EC2 instance.
-INSTANCEID=$(curl http://169.254.169.254/latest/meta-data//instance-id)
+INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
 
 # Get the ID of the Amazon EBS volume associated with the instance.
 VOLUMEID=$(aws ec2 describe-instances \
-    --instance-id $INSTANCEID \
-    --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
-    --output text)
+  --instance-id $INSTANCEID \
+  --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
+  --output text \
+  --region $REGION)
 
 # Resize the EBS volume.
 aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE
 
 # Wait for the resize to finish.
 while [ \
-    "$(aws ec2 describe-volumes-modifications \
+  "$(aws ec2 describe-volumes-modifications \
     --volume-id $VOLUMEID \
     --filters Name=modification-state,Values="optimizing","completed" \
     --query "length(VolumesModifications)"\
     --output text)" != "1" ]; do
-    sleep 1
+sleep 1
 done
 
-# Rewrite the partition table so that the partition takes up all the space that it can.
-sudo growpart /dev/xvda 1
+#Check if we're on an NVMe filesystem
+if [[ -e "/dev/xvda" && $(readlink -f /dev/xvda) = "/dev/xvda" ]]
+then
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/xvda 1
 
-# Expand the size of the file system.
-sudo xfs_growfs -d /
+  # Expand the size of the file system.
+  # Check if we're on AL2
+  STR=$(cat /etc/os-release)
+  SUB="VERSION_ID=\"2\""
+  if [[ "$STR" == *"$SUB"* ]]
+  then
+    sudo xfs_growfs -d /
+  else
+    sudo resize2fs /dev/xvda1
+  fi
+
+else
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/nvme0n1 1
+
+  # Expand the size of the file system.
+  # Check if we're on AL2
+  STR=$(cat /etc/os-release)
+  SUB="VERSION_ID=\"2\""
+  if [[ "$STR" == *"$SUB"* ]]
+  then
+    sudo xfs_growfs -d /
+  else
+    sudo resize2fs /dev/nvme0n1p1
+  fi
+fi

--- a/Cloud9Setup/pre-requisites.sh
+++ b/Cloud9Setup/pre-requisites.sh
@@ -2,18 +2,11 @@
 . /home/ec2-user/.nvm/nvm.sh
 
 #Install python3.8
-echo "Installing python3.8"
-wget https://www.python.org/ftp/python/3.8.11/Python-3.8.11.tgz
-tar xzvf Python-3.8.11.tgz
-cd Python-3.8.11
-./configure --with-ssl
-make
-sudo make install
-cd ..
-sudo rm -rf Python-3.8.11
-rm Python-3.8.11.tgz
-sudo alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8
-sudo alternatives --set python3 /usr/local/bin/python3.8
+sudo yum install -y amazon-linux-extras
+sudo amazon-linux-extras enable python3.8
+sudo yum install -y python3.8
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+sudo alternatives --set python3 /usr/bin/python3.8
 
 # Uninstall aws cli v1 and Install aws cli version-2.3.0
 sudo pip2 uninstall awscli -y
@@ -50,8 +43,6 @@ pip install git-remote-codecommit==1.15.1
 
 # Install node v14.18.1
 echo "Installing node v14.18.1"
-nvm deactivate
-nvm uninstall node
 nvm install v14.18.1
 nvm use v14.18.1
 nvm alias default v14.18.1
@@ -59,12 +50,13 @@ nvm alias default v14.18.1
 
 # Install cdk cli version 1.129.0
 echo "Installing cdk cli version 1.129.0"
-sudo npm uninstall -g aws-cdk
-sudo npm install -g aws-cdk@1.129.0
+npm uninstall -g aws-cdk
+npm install -g aws-cdk@1.129.0
 
 # Install angular version 12.1.1
 echo "Installing angular version 12.1.1"
-sudo npm install -g @angular/cli@12.1.1
+export NG_CLI_ANALYTICS=ci
+npm install -g @angular/cli@12.1.1
 
 #Install jq version 1.5
 sudo yum -y install jq-1.5

--- a/Cloud9Setup/pre-requisites.sh
+++ b/Cloud9Setup/pre-requisites.sh
@@ -43,6 +43,8 @@ pip install git-remote-codecommit==1.15.1
 
 # Install node v14.18.1
 echo "Installing node v14.18.1"
+nvm deactivate
+nvm uninstall node
 nvm install v14.18.1
 nvm use v14.18.1
 nvm alias default v14.18.1


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Switched to using Cloud9 resize script from https://docs.aws.amazon.com/cloud9/latest/user-guide/move-environment.html#move-environment-resize which includes support for nvme devices (EC2 Nitro).

Improved pre-req install script speed by using python3.8 yum package. Fixed issue with cdk and angular npm installs not working. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
