### PR TITLE
chore: update aws sdk version

### DIFF
--- a/Cloud9Setup/pre-requisites.sh
+++ b/Cloud9Setup/pre-requisites.sh
@@ -49,10 +49,10 @@ nvm install v14.18.1
 nvm use v14.18.1
 nvm alias default v14.18.1
 
-# Install cdk cli version ^2.0.0
-echo "Installing cdk cli version ^2.0.0"
+# Install cdk cli version ^2.40.0
+echo "Installing cdk cli version ^2.40.0"
 npm uninstall -g aws-cdk
-npm install -g aws-cdk@"^2.0.0"
+npm install -g aws-cdk@"^2.40.0"
 
 #Install jq version 1.5
 sudo yum -y install jq-1.5


### PR DESCRIPTION
*Issue #48, if available:*
Need to Update Pre-requisites File

*Description of changes:*
Update the `pre-requisites.sh` file under the `Cloud9Setup` folder as the minimum required `AWS SDK version 2.40.0`. After running this update, it returns like below while running the script `pre-requisites-versions-check.sh` 

> PASS : CDK version 2.51.1 installed. The minimum required version 2.40.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
