### PR TITLE
Add Graviton support for Lab1

### DIFF
--- a/Lab1/scripts/deployment.sh
+++ b/Lab1/scripts/deployment.sh
@@ -62,7 +62,9 @@ if [[ $server -eq 1 ]]; then
     exit 1
   fi
 
-  sam build -t template.yaml --use-container
+# Required to specify a specific build image because Cloud9 doesn't currently support AWS Graviton (arm64) runtimes
+# and SAM defaults to trying to build in a container of the same arch as the destination lambda.
+  sam build -t template.yaml --use-container --build-image public.ecr.aws/sam/build-python3.8
   sam deploy --config-file samconfig.toml --region="$REGION" --stack-name="$stackname"
   cd ../scripts || exit # stop execution if cd fails
 fi

--- a/Lab1/server/template.yaml
+++ b/Lab1/server/template.yaml
@@ -99,6 +99,8 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: ProductFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: ProductService/
       Handler: product_service.get_product
       Runtime: python3.8  
@@ -116,6 +118,8 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: ProductFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: ProductService/
       Handler: product_service.get_products
       Runtime: python3.8  
@@ -132,6 +136,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: ProductService/
       Handler: product_service.create_product
       Runtime: python3.8  
@@ -148,6 +154,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: ProductService/
       Handler: product_service.update_product
       Runtime: python3.8 
@@ -164,6 +172,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: ProductService/
       Handler: product_service.delete_product
       Runtime: python3.8 
@@ -214,6 +224,8 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: OrderFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: OrderService/
       Handler: order_service.get_orders
       Runtime: python3.8  
@@ -230,6 +242,8 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: OrderFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: OrderService/
       Handler: order_service.get_order
       Runtime: python3.8  
@@ -246,6 +260,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: OrderService/
       Handler: order_service.create_order
       Runtime: python3.8  
@@ -262,6 +278,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: OrderService/
       Handler: order_service.update_order
       Runtime: python3.8 
@@ -278,6 +296,8 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
+      CompatibleArchitectures:
+        - arm64
       CodeUri: OrderService/
       Handler: order_service.delete_order
       Runtime: python3.8 

--- a/Lab1/server/template.yaml
+++ b/Lab1/server/template.yaml
@@ -25,6 +25,8 @@ Resources:
   ServerlessSaaSLayers:
     Type: AWS::Serverless::LayerVersion
     Properties:
+      CompatibleArchitectures:
+        - arm64
       LayerName: serverless-saas-workshoplab1
       Description: Utilities for project
       ContentUri: layers/

--- a/Lab1/server/template.yaml
+++ b/Lab1/server/template.yaml
@@ -10,7 +10,7 @@ Globals:
   Function:
     Timeout: 29
     Layers:
-      - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:14"
+      - !Sub "arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension-Arm64:1"
     Environment:
         Variables:
           LOG_LEVEL: DEBUG                   

--- a/Lab1/server/template.yaml
+++ b/Lab1/server/template.yaml
@@ -99,7 +99,7 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: ProductFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: ProductService/
       Handler: product_service.get_product
@@ -118,7 +118,7 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: ProductFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: ProductService/
       Handler: product_service.get_products
@@ -136,7 +136,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: ProductService/
       Handler: product_service.create_product
@@ -154,7 +154,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: ProductService/
       Handler: product_service.update_product
@@ -172,7 +172,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: ProductFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: ProductService/
       Handler: product_service.delete_product
@@ -224,7 +224,7 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: OrderFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: OrderService/
       Handler: order_service.get_orders
@@ -242,7 +242,7 @@ Resources:
     Type: AWS::Serverless::Function 
     DependsOn: OrderFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: OrderService/
       Handler: order_service.get_order
@@ -260,7 +260,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: OrderService/
       Handler: order_service.create_order
@@ -278,7 +278,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: OrderService/
       Handler: order_service.update_order
@@ -296,7 +296,7 @@ Resources:
     Type: AWS::Serverless::Function
     DependsOn: OrderFunctionExecutionRole 
     Properties:
-      CompatibleArchitectures:
+      Architectures:
         - arm64
       CodeUri: OrderService/
       Handler: order_service.delete_order


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated Lab1 dependencies to all run on arm64 Lambda environments, effectively moving Lab1 to Graviton. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
