### PR TITLE
update to latest codebuild image, and specify python3.9 for tenant pi…

### DIFF
--- a/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -79,7 +79,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("Lab5/server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName

--- a/Lab5/server/tenant-buildspec.yml
+++ b/Lab5/server/tenant-buildspec.yml
@@ -4,6 +4,8 @@
 version: 0.2
 phases:
   install:    
+    runtime-versions:
+      python: 3.9
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to 1.33.0 version

--- a/Lab6/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Lab6/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -79,7 +79,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("Lab6/server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName

--- a/Lab6/server/tenant-buildspec.yml
+++ b/Lab6/server/tenant-buildspec.yml
@@ -4,6 +4,8 @@
 version: 0.2
 phases:
   install:    
+    runtime-versions:
+      python: 3.9
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to 1.33.0 version

--- a/Solution/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Solution/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -79,7 +79,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("Lab5/server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName

--- a/Solution/Lab5/server/tenant-buildspec.yml
+++ b/Solution/Lab5/server/tenant-buildspec.yml
@@ -4,6 +4,8 @@
 version: 0.2
 phases:
   install:    
+    runtime-versions:
+      python: 3.9
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to 1.33.0 version

--- a/Solution/Lab6/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Solution/Lab6/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -79,7 +79,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("Lab6/server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName

--- a/Solution/Lab6/server/tenant-buildspec.yml
+++ b/Solution/Lab6/server/tenant-buildspec.yml
@@ -4,6 +4,8 @@
 version: 0.2
 phases:
   install:    
+    runtime-versions:
+      python: 3.9
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to 1.33.0 version


### PR DESCRIPTION
…peline

*Issue #, if available:*

*Description of changes:*
We are currently using the an older version of the codebuild image (`codebuild.LinuxBuildImage.AMAZON_LINUX_2_2`). This PR updates the codebuild project to use the latest `codebuild imagecodebuild.LinuxBuildImage.AMAZON_LINUX_2_4` and also pins the python runtime to `python3.9`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
