### PR TITLE
serverless-saas-pipeline-deploytenantstack and Lambda application updated to Python3.9

### DIFF
--- a/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -31,7 +31,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
 
     const lambdaFunction = new Function(this, "deploy-tenant-stack", {
         handler: "lambda-deploy-tenant-stack.lambda_handler",
-        runtime: Runtime.PYTHON_3_8,
+        runtime: Runtime.PYTHON_3_9,
         code: new AssetCode(`./resources`),
         memorySize: 512,
         timeout: Duration.seconds(10),

--- a/Solution/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/Solution/Lab5/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -31,7 +31,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
 
     const lambdaFunction = new Function(this, "deploy-tenant-stack", {
         handler: "lambda-deploy-tenant-stack.lambda_handler",
-        runtime: Runtime.PYTHON_3_8,
+        runtime: Runtime.PYTHON_3_9,
         code: new AssetCode(`./resources`),
         memorySize: 512,
         timeout: Duration.seconds(10),


### PR DESCRIPTION
*Issue #, if available:*
Tenant Pipeline Updates to Python 3.9 cause issue with lambda to deploytenantstack #55

*Description of changes:*
serverless-saas-pipeline-deploytenantstack was still leveraging Python 3.8.  Pull request submitted to correct the serverless-saas-stack.ts in Lab5 so that the codepipeline for serverless-saas-pipeline will succeed in the deploy phase for the Lambda application

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
