### PR TITLE
Add VSCode Server support as an alternative to Cloud9

### DIFF
--- a/Cloud9Setup/README.md
+++ b/Cloud9Setup/README.md
@@ -1,5 +1,24 @@
-# Setup Cloud9
+# Setup Development Environment
+
+## Option 1: VSCode Server (Recommended)
+The Cloud9 service is being deprecated. We recommend using VSCode Server instead.
+
+```bash
+# Option 1: Using command line parameters
+sam build -t ../event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --stack-name serverless-saas-vscode-env --capabilities CAPABILITY_NAMED_IAM
+
+# Option 2: Using the provided samconfig.toml file
+sam build -t ../event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --config-file ../event-engine-assets/samconfig.toml
+```
+
+After deployment completes, you can access the VSCode Server environment using the URL and password provided in the CloudFormation outputs.
+
+## Option 2: Cloud9 (Legacy)
+If you still need to use Cloud9 (not recommended for new deployments):
+
+```bash
 sam build -t prereq-sam-template.yaml --use-container
 sam deploy
-
-
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This workshop is inspired by the [SaaS Factory Serverless SaaS reference solutio
 # Starting the workshop
 Follow this link for detailed instructions to run this workshop in your AWS Account: https://catalog.us-east-1.prod.workshops.aws/v2/workshops/b0c6ad36-0a4b-45d8-856b-8a64f0ac76bb/en-US
 
+## Development Environment Options
+
+This workshop provides two options for setting up your development environment:
+
+1. **VSCode Server (Recommended)**: A modern, feature-rich development environment that replaces Cloud9 (which is being deprecated). See the [VSCodeSetup](./VSCodeSetup/README.md) directory for instructions.
+
+2. **Cloud9 (Legacy)**: The original Cloud9-based development environment. This option is maintained for backward compatibility but is not recommended for new deployments. See the [Cloud9Setup](./Cloud9Setup/README.md) directory for instructions.
+
+For more details on the VSCode Server setup, see the [event-engine-assets](./event-engine-assets/README.md) directory.
+
 # License
 The documentation is made available under the Creative Commons Attribution-ShareAlike 4.0 International License. See the LICENSE file.
 

--- a/VSCodeSetup/.gitignore
+++ b/VSCodeSetup/.gitignore
@@ -1,0 +1,4 @@
+.aws-sam/
+.pytest_cache/
+.DS_Store
+.vscode/

--- a/VSCodeSetup/README.md
+++ b/VSCodeSetup/README.md
@@ -1,0 +1,72 @@
+# Setup VSCode Server Development Environment
+
+This directory contains scripts and instructions for setting up a VSCode Server development environment for the AWS Serverless SaaS Workshop.
+
+## Deployment Options
+
+### Option 1: Using command line parameters
+```bash
+sam build -t ../event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --stack-name serverless-saas-vscode-env --capabilities CAPABILITY_NAMED_IAM
+```
+
+### Option 2: Using the provided samconfig.toml file
+```bash
+# Using the samconfig.toml in the event-engine-assets directory
+sam build -t ../event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --config-file ../event-engine-assets/samconfig.toml
+
+# Or using the samconfig.toml in this directory
+sam build -t ../event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --config-file samconfig.toml
+```
+
+After deployment completes, you can access the VSCode Server environment using the URL and password provided in the CloudFormation outputs. The URL will open VSCode Server at the /Workshop directory, where the aws-serverless-saas-workshop repository has been cloned.
+
+## Scripts
+
+### pre-requisites.sh
+This script installs all the necessary tools and dependencies for the workshop, including:
+- Python 3.8+
+- AWS CLI
+- SAM CLI
+- Node.js
+- CDK CLI
+- git-remote-codecommit
+- VSCode Server specific requirements (nginx, code-server)
+
+### pre-requisites-versions-check.sh
+This script checks if all the required tools and dependencies are installed with the correct versions. It also verifies that the VSCode Server instance is properly configured.
+
+### increase-disk-size.sh
+This script increases the EBS volume size of the VSCode Server instance to 50 GiB.
+
+## Usage
+
+1. Deploy the VSCode Server environment using one of the deployment options above.
+2. Connect to the VSCode Server environment using the URL and password provided in the CloudFormation outputs.
+3. Run the pre-requisites-versions-check.sh script to verify that all required tools are installed:
+   ```bash
+   cd VSCodeSetup
+   chmod +x pre-requisites-versions-check.sh
+   ./pre-requisites-versions-check.sh
+   ```
+4. If any tools are missing or have incorrect versions, run the pre-requisites.sh script:
+   ```bash
+   chmod +x pre-requisites.sh
+   ./pre-requisites.sh
+   ```
+5. If you need to increase the disk size, run the increase-disk-size.sh script:
+   ```bash
+   chmod +x increase-disk-size.sh
+   ./increase-disk-size.sh
+   ```
+
+## Differences from Cloud9
+
+VSCode Server provides several advantages over Cloud9:
+- Modern, feature-rich IDE experience
+- Better performance and stability
+- Continued support (Cloud9 is being deprecated)
+- More customization options
+- Better extension support

--- a/VSCodeSetup/increase-disk-size.sh
+++ b/VSCodeSetup/increase-disk-size.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Specify the desired volume size in GiB as a command line argument. If not specified, default to 50 GiB.
+SIZE=50
+
+# Get the ID of the environment host Amazon EC2 instance.
+INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/')
+
+# Get the ID of the Amazon EBS volume associated with the instance.
+VOLUMEID=$(aws ec2 describe-instances \
+  --instance-id $INSTANCEID \
+  --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
+  --output text \
+  --region $REGION)
+
+# Resize the EBS volume.
+aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE
+
+# Wait for the resize to finish.
+while [ \
+  "$(aws ec2 describe-volumes-modifications \
+    --volume-id $VOLUMEID \
+    --filters Name=modification-state,Values="optimizing","completed" \
+    --query "length(VolumesModifications)"\
+    --output text)" != "1" ]; do
+    sleep 1
+done
+
+#Check if we're on an NVMe filesystem
+if [[ -e "/dev/xvda" && $(readlink -f /dev/xvda) = "/dev/xvda" ]]
+then
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/xvda 1
+
+  # Expand the size of the file system.
+  # Check if we're on AL2
+  STR=$(cat /etc/os-release)
+  SUB="VERSION_ID=\"2\""
+  if [[ "$STR" == *"$SUB"* ]]
+  then
+    sudo xfs_growfs -d /
+  else
+    sudo resize2fs /dev/xvda1
+  fi
+
+else
+  # Rewrite the partition table so that the partition takes up all the space that it can.
+  sudo growpart /dev/nvme0n1 1
+
+  # Expand the size of the file system.
+  # Check if we're on AL2
+  STR=$(cat /etc/os-release)
+  SUB="VERSION_ID=\"2\""
+  if [[ "$STR" == *"$SUB"* ]]
+  then
+    sudo xfs_growfs -d /
+  else
+    sudo resize2fs /dev/nvme0n1p1
+  fi
+fi

--- a/VSCodeSetup/pre-requisites-versions-check.sh
+++ b/VSCodeSetup/pre-requisites-versions-check.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+SUMMARY="Make sure all the pre-requisites checks PASS"$'\n'
+check_version() {
+  retval=0  
+  MIN_VERSION=$1
+  CURRENT_VERSION=$2
+  IFS='.' read -r -a minarr <<< "$MIN_VERSION"
+  IFS='.' read -r -a currarr <<< "$CURRENT_VERSION"
+  
+  for ((i=0; i<${#minarr[@]}; i++));
+  do
+    #echo "${currarr[$i]}, ${minarr[$i]}"
+    if [[ ${currarr[$i]} -gt ${minarr[$i]} ]]; then
+        break
+    elif [[ ${currarr[$i]} -lt ${minarr[$i]} ]]; then
+        retval=1
+        break
+    else
+        continue
+    fi        
+  done
+
+  return $retval  
+}
+
+echo "Checking python version"
+python3 --version
+PYTHON_VERSION=$(python3 --version 2>&1 | cut -d'n' -f 2 | xargs)
+PYTHON_MIN_VERSION=3.8.0
+check_version $PYTHON_MIN_VERSION $PYTHON_VERSION
+if [[ $? -eq 1 ]]; then
+    echo "ACTION REQUIRED: Need to have python version greater than or equal to $PYTHON_MIN_VERSION"
+    SUMMARY+="* ACTION REQUIRED: Need to have python version greater than or equal to $PYTHON_MIN_VERSION"$'\n'
+else 
+    SUMMARY+="* PASS : Python version $PYTHON_VERSION installed. The minimum required version $PYTHON_MIN_VERSION"$'\n'
+fi
+echo ""
+
+echo "Checking aws cli version"
+aws --version
+if [[ $? -ne 0 ]]; then
+     echo "ACTION REQUIRED: aws cli is missing, please install !!" 
+     SUMMARY+="* ACTION REQUIRED: aws cli is missing, please install !!"$'\n'
+else 
+    AWS_VERSION=$(aws --version | cut -d'P' -f 1 | xargs)
+    SUMMARY+="* PASS : $AWS_VERSION version installed"$'\n'
+    jq --version
+    if [[ $? -ne 0 ]]; then
+        echo yes | sudo yum install jq
+    fi    
+    # Check for VSCode Server instance instead of Cloud9
+    VSCODE_INSTANCE=$(aws ec2 describe-instances --filters "Name=tag:Name,Values=ServerlessSaaS-VSCode" | jq -r '.Reservations[0].Instances[0].InstanceId')
+    if [ -z "$VSCODE_INSTANCE" ]; then
+        echo "ACTION REQUIRED: Looks like VSCode Server instance is missing. Please create one using the vscode-module-sam-template.yaml template!!"
+        SUMMARY+="* ACTION REQUIRED: Looks like VSCode Server instance is missing. Please create one using the vscode-module-sam-template.yaml template!!"$'\n'
+    else
+        SUMMARY+="* PASS : VSCode Server instance found"$'\n' 
+        VSCODE_INSTANCE_VOLUME_ID=$(aws ec2 describe-instances --instance-ids $VSCODE_INSTANCE | jq -r '.Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId')
+        VOLUME_SIZE=$(aws ec2 describe-volumes --volume-ids $VSCODE_INSTANCE_VOLUME_ID | jq -r '.Volumes[0].Size')
+        if [[ $VOLUME_SIZE -lt 50 ]]; then
+            echo "ACTION REQUIRED: The volume size of VSCode Server is less than 50GiB. Please update volume size to at least 50GiB"
+            SUMMARY+="* ACTION REQUIRED: The volume size of VSCode Server is less than 50GiB. Please update volume size to at least 50GiB"$'\n'
+        else
+            SUMMARY+="* PASS : Has minimum required 50GiB volume size"$'\n'
+        fi
+        
+        # Check for CloudFront distribution
+        CLOUDFRONT_DIST=$(aws cloudfront list-distributions | jq -r '.DistributionList.Items[] | select(.Origins.Items[0].DomainName | contains("'$VSCODE_INSTANCE'")) | .Id')
+        if [ -z "$CLOUDFRONT_DIST" ]; then
+            echo "ACTION REQUIRED: CloudFront distribution for VSCode Server not found. Please check your deployment."
+            SUMMARY+="* ACTION REQUIRED: CloudFront distribution for VSCode Server not found. Please check your deployment."$'\n'
+        else
+            SUMMARY+="* PASS : CloudFront distribution for VSCode Server found"$'\n'
+        fi
+    fi
+fi
+echo ""
+
+echo "Checking sam cli version"
+sam --version
+SAM_VERSION=$(sam --version | cut -d'n' -f 2 | xargs)
+SAM_MIN_VERSION=1.53.0
+check_version $SAM_MIN_VERSION $SAM_VERSION
+if [[ $? -eq 1 ]]; then
+    echo "ACTION REQUIRED: Need to have SAM version greater than or equal to $SAM_MIN_VERSION"
+    SUMMARY+="* ACTION REQUIRED: Need to have SAM version greater than or equal to $SAM_MIN_VERSION"$'\n'
+else
+    SUMMARY+="* PASS : Sam cli version $SAM_VERSION installed. The minimum required version $SAM_MIN_VERSION"$'\n'
+fi
+echo ""
+
+echo "Checking git-remote-codecommit version"
+python3 -m pip show git-remote-codecommit
+if [[ $? -ne 0 ]]; then
+    echo "ACTION REQUIRED: git-remote-codecommit is missing, please install"
+    SUMMARY+="* ACTION REQUIRED: git-remote-codecommit is missing, please install !!"$'\n'
+else
+    SUMMARY+="* PASS : Has git-remote-codecommit installed"$'\n'
+fi
+echo ""
+
+echo "Checking node version"
+node --version
+NODE_VERSION=$(node --version | cut -d'v' -f 2)
+NODE_MIN_VERSION=14.0.0
+check_version $NODE_MIN_VERSION $NODE_VERSION 
+if [[ $? -eq 1 ]]; then
+    echo "ACTION REQUIRED: Need to have Node version greater than or equal to $NODE_MIN_VERSION"
+    SUMMARY+="* ACTION REQUIRED: Need to have Node version greater than or equal to $NODE_MIN_VERSION"$'\n'
+else
+    SUMMARY+="* PASS : Node version $NODE_VERSION installed. The minimum required version $NODE_MIN_VERSION"$'\n'
+fi
+echo ""
+
+echo "Checking cdk version"
+cdk --version
+CDK_VERSION=$(cdk --version | cut -d'(' -f 1| xargs)
+CDK_MIN_VERSION=2.40.0
+check_version $CDK_MIN_VERSION $CDK_VERSION
+if [[ $? -eq 1 ]]; then
+    echo "ACTION REQUIRED: Need to have CDK version greater than or equal to $CDK_MIN_VERSION"
+    SUMMARY+="* ACTION REQUIRED: Need to have CDK version greater than or equal to $CDK_MIN_VERSION"$'\n'
+else 
+    SUMMARY+="* PASS : CDK version $CDK_VERSION installed. The minimum required version $CDK_MIN_VERSION"$'\n'
+fi
+echo ""
+
+# Check for VSCode Server specific requirements
+echo "Checking nginx installation"
+nginx -v
+if [[ $? -ne 0 ]]; then
+    echo "ACTION REQUIRED: nginx is missing, please install"
+    SUMMARY+="* ACTION REQUIRED: nginx is missing, please install !!"$'\n'
+else
+    SUMMARY+="* PASS : nginx is installed"$'\n'
+fi
+echo ""
+
+echo "Checking code-server installation"
+code-server --version
+if [[ $? -ne 0 ]]; then
+    echo "ACTION REQUIRED: code-server is missing, please install"
+    SUMMARY+="* ACTION REQUIRED: code-server is missing, please install !!"$'\n'
+else
+    SUMMARY+="* PASS : code-server is installed"$'\n'
+fi
+echo ""
+
+echo "***************SUMMARY****************"
+echo "$SUMMARY"
+echo "***************END OF SUMMARY*********"

--- a/VSCodeSetup/pre-requisites.sh
+++ b/VSCodeSetup/pre-requisites.sh
@@ -1,0 +1,102 @@
+#!/bin/bash -x
+
+# Define the VSCode Server user
+VSCODE_USER="participant"
+
+# Installing NVM
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | sudo -u $VSCODE_USER bash
+
+. /home/$VSCODE_USER/.nvm/nvm.sh
+
+# Install python3.8 or higher
+if [ -f /etc/os-release ] && grep -q "VERSION_ID=\"2\"" /etc/os-release; then
+    # Amazon Linux 2
+    sudo yum install -y amazon-linux-extras
+    sudo amazon-linux-extras enable python3.8
+    sudo yum install -y python3.8
+    sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+    sudo alternatives --set python3 /usr/bin/python3.8
+else
+    # Amazon Linux 2023 or other distributions
+    sudo dnf install -y python3.11 python3.11-pip python3-virtualenv python3-pytest
+    sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+    sudo alternatives --set python3 /usr/bin/python3.11
+fi
+
+# Uninstall aws cli v1 and Install aws cli version-2.3.0
+sudo pip uninstall awscli -y 2>/dev/null || true
+
+echo "Installing aws cli version-2.3.0"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.3.0.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install
+rm awscliv2.zip
+rm -rf aws 
+
+# Install sam cli version 1.64.0
+echo "Installing sam cli version 1.64.0"
+wget https://github.com/aws/aws-sam-cli/releases/download/v1.64.0/aws-sam-cli-linux-x86_64.zip
+unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
+sudo ./sam-installation/install
+if [ $? -ne 0 ]; then
+    echo "Sam cli is already present, so deleting existing version"
+    sudo rm /usr/local/bin/sam
+    sudo rm -rf /usr/local/aws-sam-cli
+    echo "Now installing sam cli version 1.64.0"
+    sudo ./sam-installation/install    
+fi
+rm aws-sam-cli-linux-x86_64.zip
+rm -rf sam-installation
+
+# Install git-remote-codecommit version 1.15.1
+echo "Installing git-remote-codecommit version 1.15.1"
+curl -O https://bootstrap.pypa.io/get-pip.py
+python3 get-pip.py --user
+rm get-pip.py
+
+python3 -m pip install git-remote-codecommit==1.15.1
+
+# Install node v14.18.1
+echo "Installing node v14.18.1"
+sudo -u $VSCODE_USER bash -c "source /home/$VSCODE_USER/.nvm/nvm.sh && nvm deactivate && nvm uninstall node && nvm install v14.18.1 && nvm use v14.18.1 && nvm alias default v14.18.1"
+
+# Install cdk cli version ^2.40.0
+echo "Installing cdk cli version ^2.40.0"
+npm uninstall -g aws-cdk
+npm install -g aws-cdk@"^2.40.0"
+
+# Install jq
+if [ -f /etc/os-release ] && grep -q "VERSION_ID=\"2\"" /etc/os-release; then
+    # Amazon Linux 2
+    sudo yum -y install jq-1.5
+else
+    # Amazon Linux 2023 or other distributions
+    sudo dnf -y install jq
+fi
+
+# Install pylint version 2.11.1
+python3 -m pip install pylint==2.11.1
+
+# Install boto3
+python3 -m pip install boto3
+
+# Install VSCode Server specific requirements
+# Install nginx if not already installed
+if ! command -v nginx &> /dev/null; then
+    if [ -f /etc/os-release ] && grep -q "VERSION_ID=\"2\"" /etc/os-release; then
+        # Amazon Linux 2
+        sudo amazon-linux-extras install -y nginx1
+    else
+        # Amazon Linux 2023 or other distributions
+        sudo dnf install -y nginx
+    fi
+fi
+
+# Install code-server if not already installed
+if ! command -v code-server &> /dev/null; then
+    curl -fsSL https://code-server.dev/install.sh | sh
+    sudo systemctl enable --now code-server@$VSCODE_USER
+fi
+
+# Set proper permissions for the VSCode user
+sudo chown -R $VSCODE_USER:$VSCODE_USER /home/$VSCODE_USER

--- a/VSCodeSetup/samconfig.toml
+++ b/VSCodeSetup/samconfig.toml
@@ -1,0 +1,10 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "serverless-saas-vscode-env"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-8tf6bmi4rdcx"
+s3_prefix = "serverless-saas-vscode"
+region = "us-west-2"
+confirm_changeset = false
+capabilities = "CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND"

--- a/event-engine-assets/README.md
+++ b/event-engine-assets/README.md
@@ -1,0 +1,51 @@
+# AWS Serverless SaaS Workshop - Event Engine Assets
+
+This directory contains assets used for deploying the AWS Serverless SaaS Workshop in Event Engine environments.
+
+## Templates
+
+### VSCode Server Template (vscode-module-sam-template.yaml)
+
+This template replaces the original Cloud9-based development environment with a VSCode Server environment. Cloud9 is being deprecated, and VSCode Server provides a modern, feature-rich alternative.
+
+#### Key Features
+
+- **VSCode Server**: Deploys a VSCode Server instance on an EC2 instance
+- **CloudFront Distribution**: Provides secure access to the VSCode Server
+- **Pre-installed Tools**: Includes all necessary tools for the workshop (AWS CLI, SAM CLI, Node.js, Python, etc.)
+- **Workshop Repository**: Automatically clones the workshop repository
+- **Security**: Uses a generated password stored in AWS Secrets Manager
+
+#### Deployment
+
+To deploy the VSCode Server environment:
+
+```bash
+# Option 1: Using command line parameters
+sam build -t event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --stack-name serverless-saas-vscode-env --capabilities CAPABILITY_NAMED_IAM
+
+# Option 2: Using the provided samconfig.toml file
+sam build -t event-engine-assets/vscode-module-sam-template.yaml --use-container
+sam deploy --config-file samconfig.toml
+```
+
+After deployment, you'll receive:
+- A URL to access the VSCode Server
+- A password to log in
+
+### Legacy Cloud9 Template (initialize-module-sam-template.yaml)
+
+This is the original template that deploys a Cloud9 IDE environment. It's kept for backward compatibility but is not recommended for new deployments as Cloud9 is being deprecated.
+
+## Migration from Cloud9 to VSCode Server
+
+If you have existing workshops using Cloud9, you can update them to use VSCode Server by:
+
+1. Using the `vscode-module-sam-template.yaml` template instead of the Cloud9 template
+2. Updating any documentation to reference VSCode Server instead of Cloud9
+3. Ensuring any workshop-specific tools or configurations are included in the VSCode Server setup
+
+## Pre-requisites Scripts
+
+- `pre-requisites-event-engine.sh`: Script to install required tools and dependencies in the development environment

--- a/event-engine-assets/samconfig.toml
+++ b/event-engine-assets/samconfig.toml
@@ -1,0 +1,10 @@
+version = 0.1
+[default]
+[default.deploy]
+[default.deploy.parameters]
+stack_name = "serverless-saas-vscode-env"
+s3_bucket = "aws-sam-cli-managed-default-samclisourcebucket-8tf6bmi4rdcx"
+s3_prefix = "serverless-saas-vscode"
+region = "us-west-2"
+confirm_changeset = false
+capabilities = "CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND"

--- a/event-engine-assets/vscode-module-sam-template.yaml
+++ b/event-engine-assets/vscode-module-sam-template.yaml
@@ -1,0 +1,1237 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  Create VSCode Server IDE, create state machine to install pre-req on VSCode Server, API Gateway cloudwatch Role
+
+Parameters:
+  # Optional parameters passed by the Event Engine to the stack.
+  # EEEventId:
+  #   Description: "Unique ID of this Event"
+  #   Type: String
+  # EETeamId:
+  #   Description: "Unique ID of this Team"
+  #   Type: String
+  # EEModuleId:
+  #   Description: "Unique ID of this module"
+  #   Type: String
+  # EEModuleVersion:
+  #   Description: "Version of this module"
+  #   Type: String
+  EEAssetsBucket:
+    Description: "Region-specific assets S3 bucket name (e.g. ee-assets-prod-us-east-1)"
+    Type: String
+    Default: "aws-sam-cli-managed-default-samclisourcebucket-8tf6bmi4rdcx"
+  EEAssetsKeyPrefix:
+    Description: "S3 key prefix where this modules assets are stored. (e.g. modules/my_module/v1/)"
+    Type: String
+    Default: "serverless-saas/"
+  # EEMasterAccountId:
+  #   Description: "AWS Account Id of the Master account"
+  #   Type: String
+  # EETeamRoleArn:
+  #   Description: "ARN of the Team Role"
+  #   Type: String
+  # EEKeyPair:
+  #   Description: "Name of the EC2 KeyPair generated for the Team"
+  #   Type: AWS::EC2::KeyPair::KeyName
+  # Your own parameters for the stack. NOTE: All these parameters need to have a default value.
+  EBSVolumeSize:
+    Description: "Size of EBS Volume (in GB)"
+    Type: Number
+    Default: 50
+  UserDataScript:
+    Description: "File name for user-data script"
+    Type: String
+    Default: "pre-requisites-event-engine.sh"
+  EC2InstanceType:
+    Default: t3.large
+    Description: EC2 instance type on which IDE runs
+    Type: String
+  VSCodeUser:
+    Type: String
+    Description: UserName for VSCode Server
+    Default: participant
+  InstanceAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Description: VSCode Server EC2 AMI ID parameter path
+    Default: '/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64'
+  HomeFolder:
+    Type: String
+    Description: Folder to open in VS Code server
+    Default: /Workshop
+  OwnerRoleName:
+    Default: "ServerlessSaaS/shaanubh-Isengard"
+    Description: Use this if you are accessing your AWS Account using a cross account role (as is the case with event engine)
+    Type: String    
+
+Conditions:
+  AddUserData: !Not [!Equals [ !Ref UserDataScript, "NONE" ]]
+  UseRole: !Not [!Equals [ !Ref OwnerRoleName, ""]]
+
+Mappings:
+  AWSRegions2PrefixListID:
+    eu-central-1:
+      PrefixList: pl-a3a144ca
+    eu-north-1:
+      PrefixList: pl-fab65393
+    eu-west-1:
+      PrefixList: pl-4fa04526
+    eu-west-2:
+      PrefixList: pl-93a247fa
+    eu-west-3:
+      PrefixList: pl-75b1541c
+    us-east-1:
+      PrefixList: pl-3b927c52
+    us-east-2:
+      PrefixList: pl-b6a144df
+    us-west-1:
+      PrefixList: pl-4ea04527
+    us-west-2:
+      PrefixList: pl-82a045eb
+
+Resources:  
+  EC2SSMExecutionRole:
+    Type: AWS::IAM::Role     
+    Properties:
+      RoleName: ec2-ssm-role
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns: 
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore 
+      Policies:
+      - PolicyName: ec2-ssm-policy
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:        
+          - Effect: Allow
+            Action:
+              - "ec2:ModifyVolume"
+              - "ec2:DescribeInstances"
+              - "ec2:DescribeVolumesModifications"
+              - "logs:*"              
+            Resource: "*"        
+
+  WaitForEC2ToInitialize:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        import boto3
+        import time
+        ec2_client = boto3.client('ec2')
+        
+        def lambda_handler(event, context):
+          instance_id = event['resources'][0].split("/")[1]
+          instance_statuses = ec2_client.describe_instance_status(InstanceIds=[instance_id])
+          try:
+            state = instance_statuses['InstanceStatuses'][0]['InstanceState']['Name']
+            instance_status = instance_statuses['InstanceStatuses'][0]['InstanceStatus']['Details'][0]['Status']
+            system_status = instance_statuses['InstanceStatuses'][0]['SystemStatus']['Details'][0]['Status']
+          except Exception as _:
+            state = 'UNKNOWN'
+
+          while (instance_status != 'passed' or system_status != 'passed' or state != 'running'):
+            print("waiting for system to be ready")
+            time.sleep(30)
+            instance_statuses = ec2_client.describe_instance_status(InstanceIds=[instance_id])
+            print (instance_statuses)
+            try:
+              state = instance_statuses['InstanceStatuses'][0]['InstanceState']['Name']
+              instance_status = instance_statuses['InstanceStatuses'][0]['InstanceStatus']['Details'][0]['Status']
+              system_status = instance_statuses['InstanceStatuses'][0]['SystemStatus']['Details'][0]['Status']
+            except Exception as e:
+                print(e)
+                state = 'UNKNOWN'
+
+          environment_info = {
+            "instance_id": instance_id            
+          }
+          return environment_info
+        
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      Timeout: 900
+      Policies:
+      - Statement:        
+        - Sid: EC2
+          Effect: Allow
+          Action:
+            - "ec2:DescribeInstanceStatus"            
+          Resource: "*"
+          
+  AttachSSMRoleToEC2:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        import boto3
+        import json
+        import os
+        from time import sleep
+        iam_client= boto3.client('iam')
+        ec2_client = boto3.client('ec2')
+        
+        def lambda_handler(event, context):
+            print(event)
+            instance_id = event["instance_id"]
+            instance_profile_name = 'vscode-' + instance_id
+
+            response = ec2_client.describe_iam_instance_profile_associations(Filters=[{'Name': 'instance-id','Values': [instance_id]},{'Name': 'state','Values': ['associated']}])
+            if (len(response['IamInstanceProfileAssociations']) < 1):
+              try:
+                  create_instance_profile_response = iam_client.create_instance_profile(InstanceProfileName=instance_profile_name)
+                  print(create_instance_profile_response)
+                  sleep(30)
+              except iam_client.exceptions.EntityAlreadyExistsException as _:
+                  pass
+              
+              try:
+                  response = iam_client.add_role_to_instance_profile(
+                      InstanceProfileName=instance_profile_name,
+                      RoleName='ec2-ssm-role'
+                  )
+                  print(response)
+
+                  response = ec2_client.associate_iam_instance_profile(
+                      IamInstanceProfile={'Name': instance_profile_name},
+                      InstanceId=instance_id
+                  )
+                  print(response)
+              except iam_client.exceptions.LimitExceededException as e:
+                  print(e)
+              
+              response = ec2_client.describe_iam_instance_profile_associations(Filters=[{'Name': 'instance-id','Values': [instance_id]},{'Name': 'state','Values': ['associated']}])
+              print(response)
+              
+              while len(response['IamInstanceProfileAssociations']) < 1:
+                  print("waiting for association to finish")
+                  sleep(30)
+                  response = ec2_client.describe_iam_instance_profile_associations(Filters=[{'Name': 'instance-id','Values': [instance_id]},{'Name': 'state','Values': ['associated']}])
+
+            environment_info = {
+                "instance_id": instance_id,                                
+                "instance_profile_name": instance_profile_name
+            }
+            return environment_info
+        
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      Timeout: 900
+      Policies:
+      - Statement:
+        - Sid: ResizePolicy
+          Effect: Allow
+          Action:
+            - "ec2:DescribeIamInstanceProfileAssociations"
+            - "ec2:AssociateIamInstanceProfile"
+            - "iam:CreateInstanceProfile"
+            - "iam:AddRoleToInstanceProfile"       
+            - "iam:PassRole"     
+          Resource: "*"
+
+  SendSSMCommandtoEC2:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        import boto3
+        import json
+        import os
+        from io import BytesIO
+        s3_resource = boto3.resource('s3')
+        ssm_client = boto3.client('ssm')
+        import time
+
+        def get_preamble():
+            return f"""
+        REGION=$(curl http://169.254.169.254/latest/meta-data/placement/region)
+        aws configure set profile.default.region $REGION
+
+        SIZE={int(os.environ.get('VolumeSize', '25'))}
+
+        # Get the ID of the environment host Amazon EC2 instance.
+        INSTANCEID=$(curl http://169.254.169.254/latest/meta-data//instance-id)
+
+        # Get the ID of the Amazon EBS volume associated with the instance.
+        VOLUMEID=$(aws ec2 describe-instances \
+          --instance-id $INSTANCEID \
+          --query "Reservations[0].Instances[0].BlockDeviceMappings[0].Ebs.VolumeId" \
+          --output text)
+
+        # Resize the EBS volume.
+        aws ec2 modify-volume --volume-id $VOLUMEID --size $SIZE
+
+        # Wait for the resize to finish.
+        while [ \
+          "$(aws ec2 describe-volumes-modifications \
+            --volume-id $VOLUMEID \
+            --filters Name=modification-state,Values="optimizing","completed" \
+            --query "length(VolumesModifications)"\
+            --output text)" != "1" ]; do
+          sleep 1
+        done
+        
+        #Check if we're on an NVMe filesystem
+        if [[ -e "/dev/xvda" && $(readlink -f /dev/xvda) = "/dev/xvda" ]]
+        then
+          # Rewrite the partition table so that the partition takes up all the space that it can.
+          sudo growpart /dev/xvda 1
+
+          # Expand the size of the file system.
+          # Check if we're on AL2
+          STR=$(cat /etc/os-release)
+          SUB='VERSION_ID="2"'
+          if [[ "$STR" == *"$SUB"* ]]
+          then
+            sudo xfs_growfs -d /
+          else
+            sudo resize2fs /dev/xvda1
+          fi
+
+        else
+          # Rewrite the partition table so that the partition takes up all the space that it can.
+          sudo growpart /dev/nvme0n1 1
+
+          # Expand the size of the file system.
+          # Check if we're on AL2
+          STR=$(cat /etc/os-release)
+          SUB='VERSION_ID="2"'
+          if [[ "$STR" == *"$SUB"* ]]
+          then
+            sudo xfs_growfs -d /
+          else
+            sudo resize2fs /dev/nvme0n1p1
+          fi
+        fi
+        """
+
+        def ssm_ready(ssm_client, instance_id):
+          try:
+            response = ssm_client.describe_instance_information(Filters=[{'Key': 'InstanceIds', 'Values': [instance_id]}])
+            return len(response['InstanceInformationList'])>=1
+          except ssm_client.exceptions.InvalidInstanceId:
+            return False
+
+        def lambda_handler(event, context):
+          print(event)
+          instance_id = event["instance_id"]
+          
+          while not ssm_ready(ssm_client, instance_id):
+            print("SSM not ready yet")
+            time.sleep(30)
+            
+          try:
+            print(os.environ["S3Bucket"])
+            print(os.environ["S3Object"])
+            bucket = s3_resource.Bucket(os.environ["S3Bucket"])
+            obj = bucket.Object(os.environ["S3Object"])
+            output = BytesIO()
+            obj.download_fileobj(output)
+            commands = get_preamble() + '\n' + output.getvalue().decode('utf-8') + '\n'
+          except Exception as e:
+            print(e)
+            commands = get_preamble()
+
+          print (instance_id)
+          
+          send_command_response = ssm_client.send_command(
+            InstanceIds=[instance_id],
+            DocumentName='AWS-RunShellScript',
+            Parameters={'commands': commands.split('\n')},
+            CloudWatchOutputConfig={
+                'CloudWatchLogGroupName': f'ssm-output-{instance_id}',
+                'CloudWatchOutputEnabled': True
+            }
+          )
+
+          environment_info = {
+            "instance_id": instance_id,
+            "command_id": send_command_response['Command']['CommandId']
+          }
+          return environment_info
+
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      Timeout: 900
+      Environment:
+        Variables:
+          VolumeSize: !Ref EBSVolumeSize
+          S3Bucket: !If
+            - AddUserData
+            - !Ref EEAssetsBucket
+            - !Ref "AWS::NoValue"
+          S3Object: !If
+            - AddUserData
+            - !Sub "${EEAssetsKeyPrefix}${UserDataScript}"
+            - !Ref "AWS::NoValue"
+      Policies:
+      - Statement:
+        - Sid: ResizePolicy
+          Effect: Allow
+          Action:
+            - "s3:*"
+            - "ssm:*"
+            - "cloudwatch:*"
+          Resource: "*"
+
+  WaitForSSMCommandToComplete:
+    Type: AWS::Serverless::Function
+    Properties:
+      InlineCode: |
+        import boto3
+        import time
+
+        def lambda_handler(event, context):
+          command_id = event["command_id"]
+          instance_id = event["instance_id"]
+          ssm_client = boto3.client('ssm')
+          response = ssm_client.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
+          while (response['Status'] in ['Pending', 'InProgress', 'Delayed']):
+            time.sleep(30)
+            print("Command in Progress")
+            response = ssm_client.get_command_invocation(CommandId=command_id, InstanceId=instance_id)
+          
+      Handler: index.lambda_handler
+      Runtime: python3.9
+      Timeout: 900
+      Policies:
+      - Statement:
+        - Sid: ResizePolicy
+          Effect: Allow
+          Action:
+            - "ssm:GetCommandInvocation"
+          Resource: "*"
+            
+  BootStrapVSCodeStateMachine:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Definition:
+        StartAt: Environment Health Check
+        States:
+          Environment Health Check:
+            Type: Task
+            Resource: ${WaitForEC2ToInitializeArn}
+            Retry:
+            - ErrorEquals:
+              - States.TaskFailed
+              IntervalSeconds: 30
+              MaxAttempts: 2
+              BackoffRate: 1.5
+            Next: Attach SSM Role To EC2
+          Attach SSM Role To EC2:
+            Type: Task
+            Resource: ${AttachSSMRoleToEC2Arn}
+            Retry:
+            - ErrorEquals:
+              - States.TaskFailed
+              IntervalSeconds: 30
+              MaxAttempts: 2
+              BackoffRate: 1.5
+            Next: Send Command
+          Send Command:
+            Type: Task
+            Resource: ${SendSSMCommandtoEC2Arn}
+            Retry:
+            - ErrorEquals:
+              - States.TaskFailed
+              IntervalSeconds: 30
+              MaxAttempts: 2
+              BackoffRate: 1.5
+            Next: Wait To Stabilize
+          Wait To Stabilize:
+            Type: Task
+            Resource: ${WaitForSSMCommandToCompleteArn}
+            Retry:
+            - ErrorEquals:
+              - States.TaskFailed
+              IntervalSeconds: 30
+              MaxAttempts: 2
+              BackoffRate: 1.5
+            End: true
+      DefinitionSubstitutions:
+        WaitForEC2ToInitializeArn: !GetAtt WaitForEC2ToInitialize.Arn
+        AttachSSMRoleToEC2Arn: !GetAtt AttachSSMRoleToEC2.Arn
+        SendSSMCommandtoEC2Arn: !GetAtt SendSSMCommandtoEC2.Arn
+        WaitForSSMCommandToCompleteArn: !GetAtt WaitForSSMCommandToComplete.Arn                
+      Policies:
+      - LambdaInvokePolicy:
+          FunctionName: !Ref WaitForEC2ToInitialize
+      - LambdaInvokePolicy:
+          FunctionName: !Ref AttachSSMRoleToEC2
+      - LambdaInvokePolicy:
+          FunctionName: !Ref SendSSMCommandtoEC2
+      - LambdaInvokePolicy:
+          FunctionName: !Ref WaitForSSMCommandToComplete
+  
+  EventBridgeRole:
+    Type: AWS::IAM::Role     
+    Properties:
+      Path: '/'
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:      
+        - PolicyName: serverless-saas-eventbridge-stepfunction-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - states:StartExecution                      
+                Resource:
+                  - !GetAtt BootStrapVSCodeStateMachine.Arn              
+
+  NewVSCodeEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+        - aws.ec2
+        detail-type:
+        - EC2 Instance State-change Notification
+        detail:
+          state:
+          - running      
+      Targets:
+        - Arn : !GetAtt BootStrapVSCodeStateMachine.Arn
+          Id: "BootStrapVSCodeStateMachineTarget"
+          RoleArn: !GetAtt EventBridgeRole.Arn
+
+  # VSCode Server Resources
+  SecretPlaintextLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - !Sub lambda.${AWS::URLSuffix}
+          Action:
+          - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: AwsSecretsManager
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Ref VSCodeSecret
+
+  SecretPlaintextLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Return the value of the secret
+      Handler: index.lambda_handler
+      Runtime: python3.11
+      MemorySize: 128
+      Timeout: 10
+      Architectures:
+        - arm64
+      Role: !GetAtt SecretPlaintextLambdaRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import json
+          import cfnresponse
+          import logging
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          def is_valid_json(json_string):
+            logger.debug('Calling is_valid_jason: %s', json_string)
+            try:
+              json.loads(json_string)
+              logger.info('Secret is in json format')
+              return True
+            except json.JSONDecodeError:
+              logger.info('Secret is in string format')
+              return False
+          def lambda_handler(event, context):
+            try:
+              if event['RequestType'] == 'Delete':
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData={}, reason='No action to take')
+              else:
+                secret_name = (event['ResourceProperties']['SecretArn'])
+                secret = boto3.client('secretsmanager').get_secret_value(SecretId = secret_name)
+                logger.info('Getting secret from %s', secret_name)
+                secret_value = secret['SecretString']
+                logger.debug('secret_value: %s', secret_value)
+                responseData = {}
+                if is_valid_json(secret_value):
+                  responseData = secret_value
+                else:
+                  responseData = {'secret': secret_value}
+                logger.debug('responseData: %s', responseData)
+                logger.debug('type(responseData): %s', type(responseData))
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData=json.loads(responseData), reason='OK', noEcho=True)
+            except Exception as e:
+              cfnresponse.send(event, context, cfnresponse.FAILED, responseData={}, reason=str(e))
+
+  VSCodeSecret:
+    Type: AWS::SecretsManager::Secret
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      Name: ServerlessSaaS-VSCode
+      Description: VSCode user details
+      GenerateSecretString:
+        PasswordLength: 16
+        SecretStringTemplate: !Sub '{"username":"${VSCodeUser}"}'
+        GenerateStringKey: 'password'
+        ExcludePunctuation: true
+
+  SecretPlaintext:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt SecretPlaintextLambda.Arn
+      ServiceTimeout: 20
+      SecretArn: !Ref VSCodeSecret
+
+  VSCodeSSMDoc:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Command
+      Content:
+        schemaVersion: '2.2'
+        description: Bootstrap VSCode code-server instance
+        parameters:
+          linuxflavour:
+            type: String
+            default: 'al2023'
+          password:
+            type: String
+            default: !Ref AWS::StackId
+        mainSteps:
+          - action: aws:runShellScript
+            name: InstallBasePackagesDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - dnf install -y --allowerasing whois argon2 unzip nginx curl gnupg openssl
+          - action: aws:runShellScript
+            name: AddUserDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - !Sub |
+                  echo 'Adding user: ${VSCodeUser}'
+                  adduser -c '' ${VSCodeUser}
+                  passwd -l ${VSCodeUser}
+                  echo "${VSCodeUser}:{{ password }}" | chpasswd
+                  usermod -aG wheel ${VSCodeUser}
+                - echo "User Added. Checking configuration"
+                - !Sub getent passwd ${VSCodeUser}
+          - action: aws:runShellScript
+            name: InstallNodeDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - dnf install -y nodejs npm
+                - npm install -g npm@latest
+                - echo "Node and npm installed. Checking configuration"
+                - node -v
+                - npm -v
+          - action: aws:runShellScript
+            name: ConfigureCodeServer
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - !Sub export HOME=/home/${VSCodeUser}
+                - curl -fsSL https://code-server.dev/install.sh | bash -s -- 2>&1
+                - !Sub systemctl enable --now code-server@${VSCodeUser} 2>&1
+                - !Sub |
+                  tee /etc/nginx/conf.d/code-server.conf <<EOF
+                  server {
+                      listen 80;
+                      listen [::]:80;
+                      server_name *.cloudfront.net;
+                      location / {
+                        proxy_pass http://localhost:8080/;
+                        proxy_set_header Host \$host;
+                        proxy_set_header Upgrade \$http_upgrade;
+                        proxy_set_header Connection upgrade;
+                        proxy_set_header Accept-Encoding gzip;
+                      }
+                  }
+                  EOF
+                - !Sub mkdir -p /home/${VSCodeUser}/.config/code-server
+                - !Sub |
+                  tee /home/${VSCodeUser}/.config/code-server/config.yaml <<EOF
+                  cert: false
+                  auth: password
+                  hashed-password: "$(echo -n {{ password }} | argon2 $(openssl rand -base64 12) -e)"
+                  EOF
+                - !Sub mkdir -p /home/${VSCodeUser}/.local/share/code-server/User/
+                - !Sub touch /home/${VSCodeUser}/.hushlogin
+                - !Sub mkdir -p ${HomeFolder} && chown -R ${VSCodeUser}:${VSCodeUser} ${HomeFolder}
+                - !Sub |
+                  tee /home/${VSCodeUser}/.local/share/code-server/User/terminal.json <<EOF
+                  {
+                    "integrated.defaultProfile.linux": "bash",
+                    "integrated.cwd": "${HomeFolder}"
+                  }
+                  EOF
+                - !Sub |
+                  tee /home/${VSCodeUser}/.local/share/code-server/User/settings.json <<EOF
+                  {
+                    "extensions.autoUpdate": false,
+                    "extensions.autoCheckUpdates": false,
+                    "telemetry.telemetryLevel": "off",
+                    "security.workspace.trust.startupPrompt": "never",
+                    "security.workspace.trust.enabled": false,
+                    "security.workspace.trust.banner": "never",
+                    "security.workspace.trust.emptyWindow": false,
+                    "editor.indentSize": "tabSize",
+                    "editor.tabSize": 2,
+                    "python.testing.pytestEnabled": true,
+                    "auto-run-command.rules": [
+                      {
+                        "command": "workbench.action.terminal.new"
+                      }
+                    ]
+                  }
+                  EOF
+                - !Sub chown -R ${VSCodeUser}:${VSCodeUser} /home/${VSCodeUser}
+                - !Sub systemctl restart code-server@${VSCodeUser}
+                - systemctl restart nginx
+                - !Sub sudo -u ${VSCodeUser} --login code-server --install-extension AmazonWebServices.amazon-q-vscode --force
+                - !Sub sudo -u ${VSCodeUser} --login code-server --install-extension synedra.auto-run-command --force
+                - !Sub sudo -u ${VSCodeUser} --login code-server --install-extension vscjava.vscode-java-pack --force
+                - !Sub sudo -u ${VSCodeUser} --login code-server --install-extension ms-vscode.live-server --force
+                - !Sub chown -R ${VSCodeUser}:${VSCodeUser} /home/${VSCodeUser}
+                - echo "Nginx installed. Checking configuration"
+                - nginx -t 2>&1
+                - systemctl status nginx
+                - echo "CodeServer installed. Checking configuration"
+                - code-server -v
+                - !Sub systemctl status code-server@${VSCodeUser}
+          - action: aws:runShellScript
+            name: UpdateProfile
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - echo LANG=en_US.utf-8 >> /etc/environment
+                - echo LC_ALL=en_US.UTF-8 >> /etc/environment
+                - !Sub echo 'PATH=$PATH:/home/${VSCodeUser}/.local/bin' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'export PATH' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'export AWS_REGION=${AWS::Region}' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'export AWS_ACCOUNTID=${AWS::AccountId}' >> /home/${VSCodeUser}/.bashrc
+                - !Sub chown -R ${VSCodeUser}:${VSCodeUser} /home/${VSCodeUser}
+          - action: aws:runShellScript
+            name: InstallAWSCLI
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip -o /tmp/aws-cli.zip
+                - unzip -q -d /tmp /tmp/aws-cli.zip
+                - sudo /tmp/aws/install
+                - rm -rf /tmp/aws
+                - echo "AWS CLI installed. Checking configuration"
+                - aws --version
+          - action: aws:runShellScript
+            name: InstallDockerDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - dnf install -y docker
+                - !Sub usermod -aG docker ${VSCodeUser}
+                - !Sub systemctl restart code-server@${VSCodeUser}.service
+                - systemctl start docker.service
+          - action: aws:runShellScript
+            name: InstallGitDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - dnf install -y git
+                - !Sub sudo -u ${VSCodeUser} git config --global user.email "participant@example.com"
+                - !Sub sudo -u ${VSCodeUser} git config --global user.name "Workshop Participant"
+                - !Sub sudo -u ${VSCodeUser} git config --global init.defaultBranch "main"
+                - echo "Git installed. Checking configuration"
+                - git --version
+          - action: aws:runShellScript
+            name: InstallPythonDnf
+            precondition:
+              StringEquals:
+                - '{{ linuxflavour }}'
+                - al2023
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - dnf install -y python3.11 python3.11-pip python3-virtualenv python3-pytest
+                - !Sub echo 'alias pytest=pytest-3' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'alias python3=python3.11' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'alias python=python3.11' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'alias pip3=pip3.11' >> /home/${VSCodeUser}/.bashrc
+                - !Sub echo 'alias pip=pip3.11' >> /home/${VSCodeUser}/.bashrc
+                - !Sub source /home/${VSCodeUser}/.bashrc
+                - python3.11 -m pip install boto3 2>&1
+                - python3.11 -m pip install --upgrade pip 2>&1
+                - echo "Python and Pip installed. Checking configuration"
+                - python3.11 --version
+                - python3.11 -m pip --version 2>&1
+          - action: aws:runShellScript
+            name: InstallCDK
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - npm install -g aws-cdk
+                - echo "AWS CDK installed. Checking configuration"
+                - cdk --version
+          - action: aws:runShellScript
+            name: GitCloneRepo
+            inputs:
+              runCommand:
+                - '#!/bin/bash'
+                - !Sub |
+                  mkdir -p ${HomeFolder} && chown -R ${VSCodeUser}:${VSCodeUser} ${HomeFolder}
+                  cd ${HomeFolder}
+                  git clone --single-branch https://github.com/aws-samples/aws-serverless-saas-workshop.git
+                  echo "Git cloned to ${HomeFolder}/aws-serverless-saas-workshop"
+                  ls -la ${HomeFolder}/aws-serverless-saas-workshop
+                  chown -R ${VSCodeUser}:${VSCodeUser} ${HomeFolder}/aws-serverless-saas-workshop
+
+  RunSSMDocCustom:
+    Type: Custom::RunSSMDocLambda
+    Properties:
+      ServiceToken: !GetAtt RunSSMDocLambda.Arn
+      InstanceId: !Ref VSCodeInstance
+      DocumentName: !Ref VSCodeSSMDoc
+      CloudWatchLogGroupName: !Ref VSCodeSSMDocLogGroup
+      password: !GetAtt SecretPlaintext.password
+      ImageId: !Ref InstanceAmiId
+
+  RunSSMDocLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: RunSSMDocOnEC2
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:SendCommand
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:document/${VSCodeSSMDoc}
+                  - !Sub arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:instance/${VSCodeInstance}
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeImages
+                Resource: '*'
+
+  RunSSMDocLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Run SSM document on EC2 instance
+      Handler: index.lambda_handler
+      Runtime: python3.11
+      MemorySize: 128
+      Timeout: 20
+      Architectures:
+        - arm64
+      Role: !GetAtt RunSSMDocLambdaRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+          import logging
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+          ssm = boto3.client('ssm')
+          ec2 = boto3.client('ec2')
+
+          def lambda_handler(event, context):
+            logger.debug('event: %s', event)
+            try:
+              if event['RequestType'] != 'Create':
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData={}, reason='No action to take')
+              else:
+                resource_properties = (event['ResourceProperties'])
+                logger.debug('resource_properties: %s', resource_properties)
+
+                instance_id = (event['ResourceProperties']['InstanceId'])
+                document_name = (event['ResourceProperties']['DocumentName'])
+                cloudwatch_log_group_name = (event['ResourceProperties']['CloudWatchLogGroupName'])
+                image_id = (event['ResourceProperties']['ImageId'])
+
+                del resource_properties['ServiceToken']
+                del resource_properties['InstanceId']
+                del resource_properties['DocumentName']
+                del resource_properties['CloudWatchLogGroupName']
+                del resource_properties['ImageId']
+
+                parameters = {}
+                for key, value in resource_properties.items():
+                  parameters[key] = [value]
+
+                # Get the Linux Flavour from the image name
+                response = ec2.describe_images(ImageIds=[image_id])
+                parameters['linuxflavour'] = ['ubuntu'] if 'ubuntu' in response['Images'][0]['Name'].lower() else ['al2023']
+
+                logger.info('Running SSM Document %s on EC2 Instance %s. Logging to %s', document_name, instance_id, cloudwatch_log_group_name)
+                logger.debug('Parameters: %s', parameters)
+
+                response = ssm.send_command(
+                  InstanceIds = [instance_id],
+                  DocumentName = document_name,
+                  CloudWatchOutputConfig = {'CloudWatchLogGroupName': cloudwatch_log_group_name, 'CloudWatchOutputEnabled': True},
+                  Parameters = parameters
+                )
+                command_id = response['Command']['CommandId']
+                responseData = {'CommandId': command_id}
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, reason='OK')
+            except Exception as e:
+              cfnresponse.send(event, context, cfnresponse.FAILED, responseData={}, reason=str(e))
+
+  VSCodeSSMDocLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub /aws/ssm/${VSCodeSSMDoc}
+      RetentionInDays: 7
+
+  VSCodeInstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+                - ssm.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonQDeveloperAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3ReadOnlyAccess
+      Policies:
+        - PolicyName: SaaSWorkshopCustomPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                  - cloudformation:ListStacks
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:DeleteStack
+                  - cloudformation:GetTemplate
+                  - cloudformation:*ChangeSet
+                  - cognito-idp:ListUserPools
+                  - cognito-idp:DeleteUserPool
+                  - cognito-idp:DescribeUserPool
+                  - cognito-idp:UpdateUserPoolClient
+                  - cognito-idp:AdminSetUserPassword
+                  - dynamodb:ListTables
+                  - logs:DescribeLogGroups
+                  - s3:ListAllMyBuckets
+                  - s3:DeleteObject
+                  - s3:CreateBucket
+                  - s3:Put*
+                  - ssm:ListInstanceAssociations
+                  - ssm:UpdateInstanceInformation
+                  - sts:GetCallerIdentity
+                  - ecr:*
+                  - iam:GetRole
+                  - iam:DeleteRole
+                  - ssm:PutParameter
+                  - iam:CreateRole
+                  - iam:*RolePolicy
+                  - iam:TagRole
+                  - ssm:DeleteParameter
+                  - logs:DeleteLogGroup
+                  - sts:AssumeRole
+                  - lambda:InvokeFunction
+                Resource: '*'
+
+  VSCodeInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref VSCodeInstanceRole
+
+  VSCodeInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      BlockDeviceMappings:
+        - Ebs:
+            VolumeSize: !Ref EBSVolumeSize
+            VolumeType: gp3
+            DeleteOnTermination: true
+            Encrypted: true
+          DeviceName: /dev/xvda
+      Monitoring: true
+      ImageId: !Ref InstanceAmiId
+      InstanceType: !Ref EC2InstanceType
+      SecurityGroupIds:
+        - !Ref SecurityGroup
+      IamInstanceProfile: !Ref VSCodeInstanceProfile
+      UserData:
+        Fn::Base64: !Sub |
+          #cloud-config
+          hostname: ServerlessSaaS-VSCode
+          runcmd:
+            - !Sub mkdir -p ${HomeFolder} && chown -R ${VSCodeUser}:${VSCodeUser} ${HomeFolder}
+      Tags:
+      - Key: Name
+        Value: ServerlessSaaS-VSCode
+
+  VSCodeInstanceCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        DefaultTTL: 86400
+        MaxTTL: 31536000
+        MinTTL: 1
+        Name: !Join ['-', ['VSCodeServer', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        ParametersInCacheKeyAndForwardedToOrigin:
+          CookiesConfig:
+            CookieBehavior: all
+          EnableAcceptEncodingGzip: False
+          HeadersConfig:
+            HeaderBehavior: whitelist
+            Headers:
+              - Accept-Charset
+              - Authorization
+              - Origin
+              - Accept
+              - Referer
+              - Host
+              - Accept-Language
+              - Accept-Encoding
+              - Accept-Datetime
+          QueryStringsConfig:
+            QueryStringBehavior: all
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    DependsOn:
+     - RunSSMDocCustom
+    Properties:
+      DistributionConfig:
+        Enabled: True
+        HttpVersion: http2and3
+        PriceClass: PriceClass_100
+        CacheBehaviors:
+          - AllowedMethods:
+              - GET
+              - HEAD
+              - OPTIONS
+              - PUT
+              - PATCH
+              - POST
+              - DELETE
+            CachePolicyId: 4135ea2d-6df8-44a3-9df3-4b5a84be39ad
+            Compress: False
+            OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
+            TargetOriginId: !Sub CloudFront-${AWS::StackName}
+            ViewerProtocolPolicy: allow-all
+            PathPattern: '/proxy/*'
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - GET
+            - HEAD
+            - OPTIONS
+            - PUT
+            - PATCH
+            - POST
+            - DELETE
+          CachePolicyId: !Ref VSCodeInstanceCachePolicy
+          OriginRequestPolicyId: 216adef6-5c7f-47e4-b989-5492eafa07d3
+          TargetOriginId: !Sub CloudFront-${AWS::StackName}
+          ViewerProtocolPolicy: allow-all
+        Origins:
+          - DomainName: !GetAtt VSCodeInstance.PublicDnsName
+            Id: !Sub CloudFront-${AWS::StackName}
+            CustomOriginConfig:
+              OriginProtocolPolicy: http-only
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: SG for VSCodeServer - only allow CloudFront ingress
+      SecurityGroupIngress:
+        - Description: Allow HTTP from com.amazonaws.global.cloudfront.origin-facing
+          IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          SourcePrefixListId: !FindInMap [AWSRegions2PrefixListID, !Ref 'AWS::Region', PrefixList]
+
+  VSCodeHealthCheckLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - !Sub lambda.${AWS::URLSuffix}
+          Action:
+          - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: AwsSecretsManager
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource: !Ref VSCodeSecret
+
+  VSCodeHealthCheckLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Check VSCode Server health
+      Handler: index.lambda_handler
+      Runtime: python3.11
+      MemorySize: 128
+      Timeout: 600
+      Architectures:
+        - arm64
+      Role: !GetAtt VSCodeHealthCheckLambdaRole.Arn
+      Code:
+        ZipFile: |
+          import boto3
+          import json
+          import cfnresponse
+          import logging
+          import time
+          import http.client
+          from urllib.parse import urlparse
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          SLEEP_MS = 2900
+
+          def healthURLOk(url):
+              try:
+                  parsed_url = urlparse(url)
+                  if parsed_url.scheme == 'https':
+                      conn = http.client.HTTPSConnection(parsed_url.netloc)
+                  else:
+                      conn = http.client.HTTPConnection(parsed_url.netloc)
+
+                  conn.request("GET", parsed_url.path or "/")
+                  response = conn.getresponse()
+
+                  if 200 <= response.status < 400:
+                      logger.info(f'URL returned {response.status}')
+                      return True
+                  else:
+                      logger.debug(f'URL returned {response.status}')
+                      return False
+                      
+              except http.client.HTTPException as e:
+                  logger.info(f'URL invalid and/or endpoint not ready yet: {str(e)}')
+                  return False
+
+              except Exception as e:
+                  logger.error(e)
+                  return False
+              finally:
+                  if 'conn' in locals():
+                      conn.close()
+
+          def lambda_handler(event, context):
+              logger.debug(f'event: %s', event)
+
+              try:
+                  if event['RequestType'] != 'Create':
+                      cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData={}, reason='No action to take')
+                  else:
+                      resource_properties = (event['ResourceProperties'])
+                      logger.debug(f'resource_properties: %s', resource_properties)
+                      url = (event['ResourceProperties']['Url'])
+                      logger.info(f'Testing url: {url}')
+                      time_remaining = context.get_remaining_time_in_millis()
+                      attempt_no = 0
+                      health_check = False
+                      while (attempt_no == 0 or (time_remaining > SLEEP_MS and not health_check)):
+                          attempt_no += 1
+                          logger.info(f'Attempt: {attempt_no}. Time Remaining: {time_remaining/1000}s')
+                          health_check = healthURLOk(url)
+                          if not health_check:
+                              time.sleep(SLEEP_MS/1000)
+                          time_remaining = context.get_remaining_time_in_millis()
+                      if health_check:
+                          cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData={}, reason='VSCode healthcheck successful')
+                      else: 
+                          cfnresponse.send(event, context, cfnresponse.FAILED, responseData={}, reason='VSCode healthcheck failed. Timed out')
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, responseData={}, reason=str(e))
+
+  Healthcheck:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt VSCodeHealthCheckLambda.Arn
+      ServiceTimeout: 620
+      Url: !Sub https://${CloudFrontDistribution.DomainName}
+
+Outputs:
+  VSCodeURL:
+    Description: VSCode-Server URL
+    Value: !Sub https://${CloudFrontDistribution.DomainName}/?folder=${HomeFolder}
+  VSCodePassword:
+    Description: VSCode-Server Password
+    Value: !GetAtt SecretPlaintext.password
+  BootStrapVSCodeStateMachineArn:
+    Description: "State machine ARN"
+    Value: !Ref BootStrapVSCodeStateMachine


### PR DESCRIPTION
This commit adds support for using VSCode Server as a modern alternative to Cloud9 for the AWS Serverless SaaS Workshop. Key changes include:

1. New VSCodeSetup directory with scripts and configuration files
2. Updated README.md to reference VSCode Server as the recommended option
3. New CloudFormation template for deploying VSCode Server
4. Terminal configuration fix for working directory issues

Cloud9 support is maintained for backward compatibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
