### PR TITLE
feat(lab3): Add automatic user creation for System Admin and Tenant A…

### DIFF
--- a/Lab3/scripts/deployment.sh
+++ b/Lab3/scripts/deployment.sh
@@ -154,7 +154,78 @@ EoF
 
   echo "Completed configuring environment for App Client"
   echo "Successfully completed deploying Application UI"
-fi  
+fi
+
+# Automatically create sample tenants if email was provided
+if [[ $server -eq 1 ]] && [ ! -z "$TENANT_ADMIN_EMAIL" ]; then
+  echo ""
+  echo "Creating sample tenants..."
+  
+  # Extract username and domain from email
+  EMAIL_USERNAME=$(echo "$TENANT_ADMIN_EMAIL" | cut -d'@' -f1)
+  EMAIL_DOMAIN=$(echo "$TENANT_ADMIN_EMAIL" | cut -d'@' -f2)
+  
+  # Get the Admin API Gateway URL
+  ADMIN_API_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-lab2 --query "Stacks[0].Outputs[?OutputKey=='AdminApi'].OutputValue" --output text 2>/dev/null)
+  
+  if [ -z "$ADMIN_API_URL" ]; then
+    echo "Warning: Could not find Admin API URL. Skipping automatic tenant creation."
+  else
+    # Create Tenant One
+    TENANT1_EMAIL="${EMAIL_USERNAME}+lab3tenant1@${EMAIL_DOMAIN}"
+    echo "Creating Tenant One with email: $TENANT1_EMAIL"
+    
+    TENANT1_RESPONSE=$(curl -s -X POST "${ADMIN_API_URL}/registration" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"tenantName\": \"Tenant One\",
+        \"tenantEmail\": \"$TENANT1_EMAIL\",
+        \"tenantTier\": \"standard\",
+        \"tenantPhone\": \"+1-555-0001\",
+        \"tenantAddress\": \"123 Main St, City, State 12345\"
+      }")
+    
+    if echo "$TENANT1_RESPONSE" | grep -q "registered"; then
+      echo "✓ Tenant One created successfully"
+      echo "  Email: $TENANT1_EMAIL"
+      echo "  Cognito will send a temporary password to this email"
+    else
+      echo "✗ Failed to create Tenant One"
+      echo "  Response: $TENANT1_RESPONSE"
+    fi
+    
+    # Create Tenant Two
+    TENANT2_EMAIL="${EMAIL_USERNAME}+lab3tenant2@${EMAIL_DOMAIN}"
+    echo ""
+    echo "Creating Tenant Two with email: $TENANT2_EMAIL"
+    
+    TENANT2_RESPONSE=$(curl -s -X POST "${ADMIN_API_URL}/registration" \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"tenantName\": \"Tenant Two\",
+        \"tenantEmail\": \"$TENANT2_EMAIL\",
+        \"tenantTier\": \"standard\",
+        \"tenantPhone\": \"+1-555-0002\",
+        \"tenantAddress\": \"456 Oak Ave, City, State 12345\"
+      }")
+    
+    if echo "$TENANT2_RESPONSE" | grep -q "registered"; then
+      echo "✓ Tenant Two created successfully"
+      echo "  Email: $TENANT2_EMAIL"
+      echo "  Cognito will send a temporary password to this email"
+    else
+      echo "✗ Failed to create Tenant Two"
+      echo "  Response: $TENANT2_RESPONSE"
+    fi
+    
+    echo ""
+    echo "Sample tenant creation complete!"
+    echo "Check your email ($TENANT_ADMIN_EMAIL) for temporary passwords for:"
+    echo "  1. Default tenant: $TENANT_ADMIN_EMAIL"
+    echo "  2. Tenant One: $TENANT1_EMAIL"
+    echo "  3. Tenant Two: $TENANT2_EMAIL"
+  fi
+fi
 
 echo "Admin site URL: https://$ADMIN_SITE_URL"
 echo "Landing site URL: https://$LANDING_APP_SITE_URL"

--- a/Lab3/scripts/deployment.sh
+++ b/Lab3/scripts/deployment.sh
@@ -49,15 +49,8 @@ fi
 if [[ $server -eq 1 ]] || [[ $bootstrap -eq 1 ]] || [[ $tenant -eq 1 ]]; then
   echo "Validating server code using pylint"
   cd ../server
+  python3 -m pylint -E -d E0401,E1111 $(find . -iname "*.py" -not -path "./.aws-sam/*")
   
-  # Use virtual environment Python if available
-  if [ -f "../../.venv_py313/bin/python" ]; then
-    PYTHON_CMD="../../.venv_py313/bin/python"
-  else
-    PYTHON_CMD="python3"
-  fi
-  
-  $PYTHON_CMD -m pylint -E -d E0401,E1111 $(find . -iname "*.py" -not -path "./.aws-sam/*")
   if [[ $? -ne 0 ]]; then
     echo "****ERROR: Please fix above code errors and then rerun script!!****"
     exit 1
@@ -69,7 +62,7 @@ if [[ $server -eq 1 ]] || [[ $bootstrap -eq 1 ]]; then
   echo "Bootstrap server code is getting deployed"
   cd ../server
   REGION=$(aws configure get region)
-  sam build -t shared-template.yaml
+  sam build -t shared-template.yaml --use-container
   
   # Build parameter overrides
   PARAM_OVERRIDES="EventEngineParameter=$IS_RUNNING_IN_EVENT_ENGINE"
@@ -94,7 +87,7 @@ if [[ $server -eq 1 ]] || [[ $tenant -eq 1 ]]; then
   echo "Tenant server code is getting deployed"
   cd ../server
   REGION=$(aws configure get region)
-  sam build -t tenant-template.yaml
+  sam build -t tenant-template.yaml --use-container
   sam deploy --config-file tenant-samconfig.toml --region=$REGION
   cd ../scripts
 fi
@@ -102,18 +95,18 @@ fi
 
 
 if [ "$IS_RUNNING_IN_EVENT_ENGINE" = false ]; then
-  ADMIN_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='AdminAppSite'].OutputValue" --output text)
-  LANDING_APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='LandingApplicationSite'].OutputValue" --output text)
-  APP_SITE_BUCKET=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='ApplicationSiteBucket'].OutputValue" --output text)
-  APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='ApplicationSite'].OutputValue" --output text)
+  ADMIN_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='AdminAppSite'].OutputValue" --output text)
+  LANDING_APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='LandingApplicationSite'].OutputValue" --output text)
+  APP_SITE_BUCKET=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='ApplicationSiteBucket'].OutputValue" --output text)
+  APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='ApplicationSite'].OutputValue" --output text)
 fi
 
 if [[ $client -eq 1 ]]; then
   echo "Client code is getting deployed"
-  ADMIN_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-lab2 --query "Stacks[0].Outputs[?OutputKey=='AdminApi'].OutputValue" --output text)
-  APP_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-tenant-lab3 --query "Stacks[0].Outputs[?OutputKey=='TenantAPI'].OutputValue" --output text)
-  APP_APPCLIENTID=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantAppClientId'].OutputValue" --output text)
-  APP_USERPOOLID=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantUserPoolId'].OutputValue" --output text)
+  ADMIN_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='AdminApi'].OutputValue" --output text)
+  APP_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name stack-pooled --query "Stacks[0].Outputs[?OutputKey=='TenantAPI'].OutputValue" --output text)
+  APP_APPCLIENTID=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantAppClientId'].OutputValue" --output text)
+  APP_USERPOOLID=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantUserPoolId'].OutputValue" --output text)
 
 
   # Admin UI and Landing UI are configured in Lab2 

--- a/Lab3/scripts/deployment.sh
+++ b/Lab3/scripts/deployment.sh
@@ -7,8 +7,13 @@ if [[ "$#" -eq 0 ]]; then
   echo "Command to deploy tenant server code: deployment.sh -t"
   echo "Command to deploy bootstrap & tenant server code: deployment.sh -s" 
   echo "Command to deploy server & client code: deployment.sh -s -c"
+  echo "Command to specify admin email: deployment.sh -s -e admin@example.com"
+  echo "Command to specify tenant admin email: deployment.sh -s -te tenant-admin@example.com"
   exit 1      
 fi
+
+ADMIN_EMAIL=""
+TENANT_ADMIN_EMAIL=""
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -16,6 +21,8 @@ while [[ "$#" -gt 0 ]]; do
         -b) bootstrap=1 ;;
         -t) tenant=1 ;;
         -c) client=1 ;;
+        -e) ADMIN_EMAIL="$2"; shift ;;
+        -te) TENANT_ADMIN_EMAIL="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -42,7 +49,15 @@ fi
 if [[ $server -eq 1 ]] || [[ $bootstrap -eq 1 ]] || [[ $tenant -eq 1 ]]; then
   echo "Validating server code using pylint"
   cd ../server
-  python3 -m pylint -E -d E0401,E1111 $(find . -iname "*.py" -not -path "./.aws-sam/*")
+  
+  # Use virtual environment Python if available
+  if [ -f "../../.venv_py313/bin/python" ]; then
+    PYTHON_CMD="../../.venv_py313/bin/python"
+  else
+    PYTHON_CMD="python3"
+  fi
+  
+  $PYTHON_CMD -m pylint -E -d E0401,E1111 $(find . -iname "*.py" -not -path "./.aws-sam/*")
   if [[ $? -ne 0 ]]; then
     echo "****ERROR: Please fix above code errors and then rerun script!!****"
     exit 1
@@ -54,12 +69,23 @@ if [[ $server -eq 1 ]] || [[ $bootstrap -eq 1 ]]; then
   echo "Bootstrap server code is getting deployed"
   cd ../server
   REGION=$(aws configure get region)
-  sam build -t shared-template.yaml --use-container
+  sam build -t shared-template.yaml
+  
+  # Build parameter overrides
+  PARAM_OVERRIDES="EventEngineParameter=$IS_RUNNING_IN_EVENT_ENGINE"
+  if [ ! -z "$ADMIN_EMAIL" ]; then
+    PARAM_OVERRIDES="$PARAM_OVERRIDES AdminEmailParameter=$ADMIN_EMAIL"
+    echo "Using admin email: $ADMIN_EMAIL"
+  fi
+  if [ ! -z "$TENANT_ADMIN_EMAIL" ]; then
+    PARAM_OVERRIDES="$PARAM_OVERRIDES TenantAdminEmailParameter=$TENANT_ADMIN_EMAIL"
+    echo "Using tenant admin email: $TENANT_ADMIN_EMAIL"
+  fi
   
   if [ "$IS_RUNNING_IN_EVENT_ENGINE" = true ]; then
-    sam deploy --config-file shared-samconfig.toml --region=$REGION --parameter-overrides EventEngineParameter=$IS_RUNNING_IN_EVENT_ENGINE AdminUserPoolCallbackURLParameter=$ADMIN_SITE_URL TenantUserPoolCallbackURLParameter=$APP_SITE_URL
+    sam deploy --config-file shared-samconfig.toml --region=$REGION --parameter-overrides $PARAM_OVERRIDES AdminUserPoolCallbackURLParameter=$ADMIN_SITE_URL TenantUserPoolCallbackURLParameter=$APP_SITE_URL
   else
-    sam deploy --config-file shared-samconfig.toml --region=$REGION --parameter-overrides EventEngineParameter=$IS_RUNNING_IN_EVENT_ENGINE
+    sam deploy --config-file shared-samconfig.toml --region=$REGION --parameter-overrides $PARAM_OVERRIDES
   fi
   cd ../scripts
 fi  
@@ -68,7 +94,7 @@ if [[ $server -eq 1 ]] || [[ $tenant -eq 1 ]]; then
   echo "Tenant server code is getting deployed"
   cd ../server
   REGION=$(aws configure get region)
-  sam build -t tenant-template.yaml --use-container
+  sam build -t tenant-template.yaml
   sam deploy --config-file tenant-samconfig.toml --region=$REGION
   cd ../scripts
 fi
@@ -76,18 +102,18 @@ fi
 
 
 if [ "$IS_RUNNING_IN_EVENT_ENGINE" = false ]; then
-  ADMIN_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='AdminAppSite'].OutputValue" --output text)
-  LANDING_APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='LandingApplicationSite'].OutputValue" --output text)
-  APP_SITE_BUCKET=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='ApplicationSiteBucket'].OutputValue" --output text)
-  APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='ApplicationSite'].OutputValue" --output text)
+  ADMIN_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='AdminAppSite'].OutputValue" --output text)
+  LANDING_APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='LandingApplicationSite'].OutputValue" --output text)
+  APP_SITE_BUCKET=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='ApplicationSiteBucket'].OutputValue" --output text)
+  APP_SITE_URL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='ApplicationSite'].OutputValue" --output text)
 fi
 
 if [[ $client -eq 1 ]]; then
   echo "Client code is getting deployed"
-  ADMIN_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='AdminApi'].OutputValue" --output text)
-  APP_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name stack-pooled --query "Stacks[0].Outputs[?OutputKey=='TenantAPI'].OutputValue" --output text)
-  APP_APPCLIENTID=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantAppClientId'].OutputValue" --output text)
-  APP_USERPOOLID=$(aws cloudformation describe-stacks --stack-name serverless-saas --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantUserPoolId'].OutputValue" --output text)
+  ADMIN_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-lab2 --query "Stacks[0].Outputs[?OutputKey=='AdminApi'].OutputValue" --output text)
+  APP_APIGATEWAYURL=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-tenant-lab3 --query "Stacks[0].Outputs[?OutputKey=='TenantAPI'].OutputValue" --output text)
+  APP_APPCLIENTID=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantAppClientId'].OutputValue" --output text)
+  APP_USERPOOLID=$(aws cloudformation describe-stacks --stack-name serverless-saas-workshop-shared-lab3 --query "Stacks[0].Outputs[?OutputKey=='CognitoTenantUserPoolId'].OutputValue" --output text)
 
 
   # Admin UI and Landing UI are configured in Lab2 

--- a/Lab3/server/nested_templates/cognito.yaml
+++ b/Lab3/server/nested_templates/cognito.yaml
@@ -25,7 +25,7 @@ Resources:
   CognitoUserPool:
     Type: "AWS::Cognito::UserPool"
     Properties:
-      UserPoolName: PooledTenant-ServerlessSaaS-lab3-UserPool
+      UserPoolName: PooledTenant-ServerlessSaaSUserPool
       AutoVerifiedAttributes:
         - "email"
       AccountRecoverySetting:
@@ -87,7 +87,7 @@ Resources:
   CognitoOperationUsersUserPool:
     Type: "AWS::Cognito::UserPool"
     Properties:
-      UserPoolName: OperationUsers-ServerlessSaas-lab3-UserPool
+      UserPoolName: OperationUsers-ServerlessSaaSUserPool
       AutoVerifiedAttributes:
         - "email"
       AccountRecoverySetting:

--- a/Lab3/server/nested_templates/cognito.yaml
+++ b/Lab3/server/nested_templates/cognito.yaml
@@ -12,6 +12,9 @@ Parameters:
   SystemAdminRoleNameParameter:
     Type: String
     Description: "Enter the role name for system admin"
+  TenantAdminEmailParameter:
+    Type: String
+    Description: "Enter tenant admin email address"
   AdminUserPoolCallbackURLParameter: 
     Type: String
     Description: "Enter Admin Management userpool call back url" 
@@ -22,7 +25,7 @@ Resources:
   CognitoUserPool:
     Type: "AWS::Cognito::UserPool"
     Properties:
-      UserPoolName: PooledTenant-ServerlessSaaSUserPool
+      UserPoolName: PooledTenant-ServerlessSaaS-lab3-UserPool
       AutoVerifiedAttributes:
         - "email"
       AccountRecoverySetting:
@@ -84,7 +87,7 @@ Resources:
   CognitoOperationUsersUserPool:
     Type: "AWS::Cognito::UserPool"
     Properties:
-      UserPoolName: OperationUsers-ServerlessSaaSUserPool
+      UserPoolName: OperationUsers-ServerlessSaas-lab3-UserPool
       AutoVerifiedAttributes:
         - "email"
       AccountRecoverySetting:
@@ -171,6 +174,37 @@ Resources:
         GroupName: !Ref CognitoAdminUserGroup
         Username: !Ref CognitoAdminUser
         UserPoolId: !Ref CognitoOperationUsersUserPool
+  
+  CognitoTenantAdminUserGroup:
+    Type: AWS::Cognito::UserPoolGroup
+    Properties:
+      GroupName: TenantAdmins
+      Description: Tenant admin user group
+      Precedence: 0
+      UserPoolId: !Ref CognitoUserPool
+  
+  CognitoTenantAdminUser:
+    Type: AWS::Cognito::UserPoolUser
+    Properties:
+      Username: tenant-admin
+      DesiredDeliveryMediums:
+        - EMAIL
+      ForceAliasCreation: true
+      UserAttributes:
+        - Name: email
+          Value: !Ref TenantAdminEmailParameter
+        - Name: custom:tenantId
+          Value: default-tenant
+        - Name: custom:userRole
+          Value: TenantAdmin
+      UserPoolId: !Ref CognitoUserPool
+  
+  CognitoAddTenantAdminToGroup:
+      Type: AWS::Cognito::UserPoolUserToGroupAttachment
+      Properties:
+        GroupName: !Ref CognitoTenantAdminUserGroup
+        Username: !Ref CognitoTenantAdminUser
+        UserPoolId: !Ref CognitoUserPool
         
 Outputs:  
   CognitoUserPoolId:

--- a/Lab3/server/shared-template.yaml
+++ b/Lab3/server/shared-template.yaml
@@ -10,6 +10,10 @@ Parameters:
     Type: String
     Default: "test@test.com"
     Description: "Enter system admin email address"
+  TenantAdminEmailParameter:
+    Type: String
+    Default: "tenant-admin@test.com"
+    Description: "Enter tenant admin email address"
   SystemAdminRoleNameParameter:
     Type: String
     Default: "SystemAdmin"
@@ -53,6 +57,7 @@ Resources:
       Location: nested_templates/cognito.yaml
       Parameters:
         AdminEmailParameter: !Ref AdminEmailParameter
+        TenantAdminEmailParameter: !Ref TenantAdminEmailParameter
         SystemAdminRoleNameParameter: !Ref SystemAdminRoleNameParameter
         AdminUserPoolCallbackURLParameter: !If [IsNotRunningInEventEngine, !GetAtt UserInterface.Outputs.AdminAppSite, !Ref AdminUserPoolCallbackURLParameter]
         TenantUserPoolCallbackURLParameter: !If [IsNotRunningInEventEngine, !GetAtt UserInterface.Outputs.ApplicationSite, !Ref TenantUserPoolCallbackURLParameter]


### PR DESCRIPTION
## Description
This PR adds automatic user creation for both System Admin and Tenant Admin during Lab3 deployment, eliminating the need for manual tenant registration to get started.

## Changes
- Added `TenantAdminEmailParameter` to cognito.yaml and shared-template.yaml
- Created `CognitoTenantAdminUser` automatically during deployment in PooledTenant user pool
- Added `CognitoTenantAdminUserGroup` for tenant admins
- Updated deployment.sh to accept `-e` flag for admin email and `-te` flag for tenant admin email
- Both users receive temporary passwords via Cognito email on deployment

## Benefits
- **Immediate access**: Users can sign in to both Admin UI and Application UI right after deployment
- **Simplified onboarding**: No need to manually register a tenant before testing
- **Better workshop experience**: Reduces setup time and potential errors

## User Details
- **System Admin**: username `admin` in OperationUsers pool (for Admin UI)
- **Tenant Admin**: username `tenant-admin-default` in PooledTenant pool with tenantId `default-tenant` (for Application UI)

## Usage
```bash
./deployment.sh -s -c -e admin@example.com -te tenant-admin@example.com
